### PR TITLE
Keep running setup option

### DIFF
--- a/src/bin/setup.py
+++ b/src/bin/setup.py
@@ -17,6 +17,7 @@ from src.utilities.cli import (
     get_wuwa_install_location,
     get_startup_preference,
     get_promote_preference,
+    get_keep_running_preference,
 )
 
 console = Console()
@@ -96,6 +97,11 @@ def get_config(console: Console) -> dict:
             console,
             "Launch on Startup Preference",
             lambda: get_startup_preference(console),
+        ),
+        "keep_running_preference": get_input(
+            console,
+            "Keep Running Preference",
+            lambda: get_keep_running_preference(console),
         ),
         "shortcut_preference": get_input(
             console,

--- a/src/utilities/cli/__init__.py
+++ b/src/utilities/cli/__init__.py
@@ -9,4 +9,5 @@ from .input import (
     get_rich_presence_install_location,
     get_wuwa_install_location,
     get_promote_preference,
+    get_keep_running_preference,
 )

--- a/src/utilities/cli/input.py
+++ b/src/utilities/cli/input.py
@@ -218,6 +218,23 @@ def get_promote_preference(console: Console) -> bool:
     )
 
 
+def get_keep_running_preference(console: Console) -> bool:
+    """
+    Get the user's preference for keeping the rich presence running after Wuthering Waves is closed
+
+    :param console: The console to use for input and output
+    :return: The user's preference for keeping the rich presence running in the background
+    """
+    return get_boolean_input(
+        console,
+        indent(
+            "Would you like to keep the rich presence running in the background?",
+            "This will keep the rich presence running after Wuthering Waves is closed,",
+            "and it will wait for the next launch (Y/N): ",
+        ),
+    )
+
+
 def get_input(console, divider_text, callback) -> any:
     """
     Get input from the user using the provided callback

--- a/src/utilities/rpc/presence.py
+++ b/src/utilities/rpc/presence.py
@@ -62,8 +62,8 @@ class Presence:
                 sleep(15)
 
             self.logger.info("Wuthering Waves and Discord are running, starting RPC...")
-            self.start = time()
-            self.presence.update(start=self.start)
+            self.start_time = time()
+            self.presence.update(start=self.start_time)
             self.rpc_loop()
         except Exception as e:
             self.logger.error(f"An uncaught error occured: {e}")
@@ -76,6 +76,15 @@ class Presence:
         while self.wuwa_process_exists():
             self.update()
             sleep(15)
+
+        if self.config["keep_running_preference"]:
+            self.presence.close()
+            while not self.wuwa_process_exists():
+                self.logger.info(
+                    "Wuthering waves has closed, waiting for it to start again..."
+                )
+                sleep(30)
+            self.start()
 
         self.logger.info("Wuthering Waves has closed, closing RPC...")
         self.presence.close()
@@ -101,7 +110,7 @@ class Presence:
         # Update the RPC with only basic information if the user doesn't want to access the database
         if self.local_database is None:
             self.presence.update(
-                start=self.start,
+                start=self.start_time,
                 details="Exploring SOL-III",
                 large_image=DiscordAssets.LARGE_IMAGE,
                 large_text="Wuthering Waves",
@@ -114,7 +123,7 @@ class Presence:
         game_version = get_game_version(self.local_database)
 
         self.presence.update(
-            start=self.start,
+            start=self.start_time,
             details=f"Union Level {union_level}",
             state=f"Region: {region}",
             large_image=DiscordAssets.LARGE_IMAGE,


### PR DESCRIPTION
# New additions

## New setup option
- This pull requests introduces a new setup option which allows users to keep the RPC on after Wuthering Waves has closed, meaning that it doesn't need to be launched again when reopening Wuthering Waves