### PR TITLE
Add Kuro Games UID setup option

### DIFF
--- a/src/bin/setup.py
+++ b/src/bin/setup.py
@@ -18,6 +18,7 @@ from src.utilities.cli import (
     get_startup_preference,
     get_promote_preference,
     get_keep_running_preference,
+    get_kuro_games_uid,
 )
 
 console = Console()
@@ -75,17 +76,27 @@ def get_config(console: Console) -> dict:
 
     :param console: The console to use for input and output
     """
-    return {
-        "wuwa_install_location": get_input(
+    wuwa_install_location = get_input(
+        console,
+        "Wuthering Waves Install Location",
+        lambda: get_wuwa_install_location(console, DEFAULT_WUWA_INSTALL_LOCATION),
+    )
+    database_access_preference = get_input(
+        console,
+        "Database Access Preference",
+        lambda: get_database_access_preference(console),
+    )
+
+    if database_access_preference:
+        kuro_games_uid = get_input(
             console,
-            "Wuthering Waves Install Location",
-            lambda: get_wuwa_install_location(console, DEFAULT_WUWA_INSTALL_LOCATION),
-        ),
-        "database_access_preference": get_input(
-            console,
-            "Database Access Preference",
-            lambda: get_database_access_preference(console),
-        ),
+            "Kuro Games UID",
+            lambda: get_kuro_games_uid(console),
+        )
+
+    config = {
+        "wuwa_install_location": wuwa_install_location,
+        "database_access_preference": database_access_preference,
         "rich_presence_install_location": get_input(
             console,
             "Rich Presence Install Location",
@@ -114,6 +125,11 @@ def get_config(console: Console) -> dict:
             lambda: get_promote_preference(console),
         ),
     }
+
+    if database_access_preference:
+        config["kuro_games_uid"] = kuro_games_uid
+
+    return config
 
 
 def create_config_folder(console: Console, config: dict) -> None:

--- a/src/utilities/cli/__init__.py
+++ b/src/utilities/cli/__init__.py
@@ -10,4 +10,5 @@ from .input import (
     get_wuwa_install_location,
     get_promote_preference,
     get_keep_running_preference,
+    get_kuro_games_uid,
 )

--- a/src/utilities/cli/input.py
+++ b/src/utilities/cli/input.py
@@ -1,3 +1,4 @@
+import re
 from os import path, listdir, makedirs
 from shutil import rmtree
 from rich.console import Console
@@ -233,6 +234,33 @@ def get_keep_running_preference(console: Console) -> bool:
             "and it will wait for the next launch (Y/N): ",
         ),
     )
+
+
+def get_kuro_games_uid(console: Console) -> str:
+    """
+    Get the Kuro Games UID the user wants to check for
+
+    :param console: The console to use for input and output
+    :return: The Kuro Games UID the user wants to check for
+    """
+    while True:
+        kuro_games_uid_regex = re.compile(r"^\d+$")
+        user_input = console.input(
+            indent(
+                "Please enter the Kuro Games UID you would like the RPC to check for.",
+                "Note that this is not the UID you see in the bottom right corner of the game.",
+                "To get this UID, go to the game's settings and click on the 'Account' tab,",
+                "then go into the 'User Center' section, and you will see the UID there: ",
+            )
+        ).strip()
+
+        if user_input and kuro_games_uid_regex.match(user_input):
+            return user_input
+        else:
+            console.print(
+                indent("\n", "The Kuro Games UID must only contain numbers", "\n"),
+                style="red",
+            )
 
 
 def get_input(console, divider_text, callback) -> any:

--- a/src/utilities/rpc/presence.py
+++ b/src/utilities/rpc/presence.py
@@ -71,7 +71,9 @@ class Presence:
                 self.logger.info(f"Found LocalStorage file: {file}")
 
                 connection = get_database(os.path.join(directory, file))
-                union_level = get_player_union_level(connection)
+                union_level = get_player_union_level(
+                    connection, self.config["kuro_games_uid"]
+                )
 
                 if union_level == "Unknown":
                     continue
@@ -175,8 +177,12 @@ class Presence:
                     self.logger.error(f"Failed to connect to database: {e}")
                     self.local_database = None
 
-            region = get_player_region(self.local_database)
-            union_level = get_player_union_level(self.local_database)
+            region = get_player_region(
+                self.local_database, self.config["kuro_games_uid"]
+            )
+            union_level = get_player_union_level(
+                self.local_database, self.config["kuro_games_uid"]
+            )
             game_version = get_game_version(self.local_database)
         except self.local_database.Error as e:
             self.logger.error(f"Failed to retrieve game data: {e}")


### PR DESCRIPTION
This pull request adds a Kuro Games UID setup option that lets the RPC correctly fetch the player's union level and region